### PR TITLE
Mention other specific errors in case people are searching for them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Maximum number of attempts. Default: 1
 
 If you would like requestXn to retry on a network error, set this options to a value above 1.
 
+This handles all non-HTTP errors including ENOTFOUND, ECONNRESET, ECONNREFUSED, and ETIMEOUT. 
+
 ```js
 max: 1
 ```


### PR DESCRIPTION
Avoids confusion as seen in #4.